### PR TITLE
Use platform's classpath separator char.

### DIFF
--- a/src/main/java/com/github/johnpoth/JShellMojo.java
+++ b/src/main/java/com/github/johnpoth/JShellMojo.java
@@ -32,6 +32,23 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 public class JShellMojo extends AbstractMojo
 {
 
+    private static final pathSeparator;
+    
+    static 
+    {
+        //Guard against possible JVM that doesn't supply this property or user deletion of it for some reason
+        //In this case then assume UNIX-style.
+        String sep = System.getProperties().getProperty("path.separator");
+        if(sep == null || sep.trim().length() == 0)
+        {
+            pathSeparator = ":";
+        }
+        else
+        {
+            pathSeparator = sep;
+        }
+    }
+
     @Parameter(defaultValue = "${project.runtimeClasspathElements}", property = "rcp", required = true)
     private List<String> runtimeClasspathElements;
 
@@ -44,9 +61,9 @@ public class JShellMojo extends AbstractMojo
     public void execute() throws MojoExecutionException {
         String cp;
         if (testClasspath) {
-            cp = testClasspathElements.stream().reduce(runtimeClasspathElements.get(0), (a, b) -> a + ":" + b);
+            cp = testClasspathElements.stream().reduce(runtimeClasspathElements.get(0), (a, b) -> a + pathSeparator + b);
         } else {
-            cp = runtimeClasspathElements.stream().reduce(runtimeClasspathElements.get(0), (a, b) -> a + ":" + b);
+            cp = runtimeClasspathElements.stream().reduce(runtimeClasspathElements.get(0), (a, b) -> a + pathSeparator + b);
         }
         getLog().debug("Using classpath:" + cp);
         Optional<Module> module = ModuleLayer.boot().findModule("jdk.jshell");


### PR DESCRIPTION
On Windows with Java 9 or 10, I receive an error like the following:

```
[INFO] --- jshell-maven-plugin:1.0:run (default-cli) @ conanpatcher-server ---
File 'C:\Users\Sean\workspace\myproject\target\classes:C:\Users\Sean\workspace\myproject\target\classes:C
:\Users\Sean\.m2\repository\com\vaadin\vaadin-server\8.4.2\vaadin-server-8.4.2.jar:C:\Users\Sean\.m2\repository\com\vaadin\vaadin-sass-
compiler\0.9.13\vaadin-sass-compiler-0.9.13.jar:C:\Users\Sean\.m2\repository\org\w3c\css\sac\1.3\sac-1.3.jar:C:\Users\Sean\.m2\reposito
ry\com\vaadin\external\flute\flute\1.3.0.gg2\flute-1.3.0.gg2.jar:C:\Users\Sean\.m2\repository\com\vaadin\vaadin-shared\8.4.2\vaadin-sha
red-8.4.2.jar:C:\Users\Sean\.m2\repository\org\jsoup\jsoup\1.11.2\jsoup-1.11.2.jar:C:\Users\Sean\.m2\repository\com\vaadin\external\gen
tyref\1.2.0.vaadin1\gentyref-1.2.0.vaadin1.jar:C:\Users\Sean\.m2\repository\com\vaadin\vaadin-push\8.4.2\vaadin-push-8.4.2.jar:C:\Users
\Sean\.m2\repository\com\vaadin\external\atmosphere\atmosphere-runtime\2.4.24.vaadin1\atmosphere-runtime-2.4.24.vaadin1.jar:C:\Users\Se
an\.m2\repository\com\vaadin\external\slf4j\vaadin-slf4j-jdk14\1.6.1\vaadin-slf4j-jdk14-1.6.1.jar:C:\Users\Sean\.m2\repository\com\vaad
in\vaadin-client-compiled\8.4.2\vaadin-client-compiled-8.4.2.jar:C:\Users\Sean\.m2\repository\com\vaadin\vaadin-themes\8.4.2\vaadin-the
mes-8.4.2.jar' for '--class-path' is not found.
```

The proper argument to pass to `--class-path` on Windows would be `;` separated paths, not `:` separated paths.

Per [Stack Overflow](https://stackoverflow.com/a/4528456/420156) the Classpath separator character is platform-dependent.

I learned how to dynamically query the path separator [here](https://kodejava.org/how-do-i-get-path-classpath-separator/):

```
Properties properties = System.getProperties();
String pathSeparator = properties.getProperty("path.separator");
```

On [L47](https://github.com/johnpoth/jshell-maven-plugin/blob/master/src/main/java/com/github/johnpoth/JShellMojo.java#L47) and [L49](https://github.com/johnpoth/jshell-maven-plugin/blob/master/src/main/java/com/github/johnpoth/JShellMojo.java#L49) of JShellMojo.java, instead of `":"` we should use pathSeparator.

Also, since this is a system property that is susceptible to being overridden or for some reason forcibly blanked out for reasons beyond our control, if we detect that the system property is null or blank, we will simply assume the user means for us to use the UNIX-like OS path separator of `:`, because it makes no sense to have *nothing* as the separator (assuming that the user setting such a property to blank doesn't completely break Maven already).